### PR TITLE
feat: add `GGUFHeader::read`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ homepage = "https://github.com/Jimexist/gguf"
 include = ["/src", "README.md"]
 
 [dependencies]
+bytes = { version = "1.5", optional = true }
+clap = { version = "4", optional = true, features = ["derive"] }
+comfy-table = { version = "7", optional = true }
 nom = { version = "7", features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.9", optional = true }
 serde_json = { version = "1.0", optional = true }
-bytes = { version = "1.5", optional = true }
-comfy-table = { version = "7", optional = true }
-clap = { version = "4", optional = true, features = ["derive"] }
 
 [features]
 bin = ["serde_yaml", "serde_json", "comfy-table", "bytes", "clap"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 //! # GGUF file parsing and struct definitions
 pub mod parser;
 use parser::{gguf_file, gguf_header};
-use std::fmt;
-extern crate serde;
 use serde::ser::SerializeSeq;
+use std::fmt;
 
 /// GGUF metadata value type
 #[derive(serde::Serialize, Debug, Clone, Copy, PartialEq)]
@@ -184,7 +183,7 @@ pub struct GGUFMetadata {
 }
 
 /// GGUF metadata value
-#[derive(PartialEq, serde::Serialize)]
+#[derive(Clone, PartialEq, serde::Serialize)]
 #[serde(untagged)]
 pub enum GGUFMetadataValue {
     Uint8(u8),
@@ -235,7 +234,7 @@ impl fmt::Debug for GGUFMetadataValue {
     }
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(Clone, PartialEq, Debug, serde::Serialize)]
 pub struct GGUFMetadataArrayValue {
     #[serde(rename = "type")]
     pub value_type: GGUfMetadataValueType,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,7 +83,7 @@ fn gguf_metadata(i: &[u8]) -> IResult<&[u8], GGUFMetadata> {
 }
 
 /// parse header
-fn gguf_header(i: &[u8]) -> IResult<&[u8], GGUFHeader> {
+pub(crate) fn gguf_header(i: &[u8]) -> IResult<&[u8], GGUFHeader> {
     let (i, _) = magic(i)?;
     let (i, version) = le_u32(i)?;
     let (i, tensor_count) = le_u64(i)?;


### PR DESCRIPTION
Hello!

I needed a way to only read headers of `.gguf` files for performance reasons.

So I forked the repo and added what I needed to make it work.

cf https://github.com/McPatate/gguf-jinja-analysis if you're curious of what I used it for 😉 

This PR does:
- add `GGUFHeader::read` as a public method
- add `Clone` to `GGUFMetadataArrayValue` & `GGUFMetadataValue`
- re-order dependencies in `Cargo.toml` (sorry OCD, can revert if you don't care for the change)

You can disregard this PR if it's not of any use.